### PR TITLE
Tags search

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,19 +2,19 @@
 
 module.exports = {
   siteMetadata: {
-    title: `Postman Blog`,
+    title: 'Postman Blog',
     description: '',
-    author: `Postman`,
+    author: 'Postman',
     siteUrl: 'https://blog.postman.com/',
   },
   plugins: [
     {
-      resolve: "gatsby-source-graphql",
+      resolve: 'gatsby-source-graphql',
       options: {
-        typeName: "WPGraphQL",
-        fieldName: "wpgraphql",
-        url: `https://blog.postman.com/graphql`,
-        refetchInterval: 60
+        typeName: 'WPGraphQL',
+        fieldName: 'wpgraphql',
+        url: 'https://blog.postman.com/graphql',
+        refetchInterval: 240,
       },
     },
     // {
@@ -30,16 +30,16 @@ module.exports = {
     //     debugOutput: true,
     //   },
     // },
-    `gatsby-plugin-react-helmet`,
+    'gatsby-plugin-react-helmet',
     {
-      resolve: `gatsby-source-filesystem`,
+      resolve: 'gatsby-source-filesystem',
       options: {
-        name: `images`,
+        name: 'images',
         path: `${__dirname}/src/images`,
       },
     },
-    `gatsby-transformer-sharp`,
-    `gatsby-plugin-sharp`,
+    'gatsby-transformer-sharp',
+    'gatsby-plugin-sharp',
     'gatsby-plugin-sass',
     'gatsby-plugin-sharp',
     {
@@ -63,19 +63,19 @@ module.exports = {
       },
     },
     {
-      resolve: `gatsby-plugin-manifest`,
+      resolve: 'gatsby-plugin-manifest',
       options: {
-        name: `gatsby-starter-default`,
-        short_name: `starter`,
-        start_url: `/`,
-        background_color: `#663399`,
-        theme_color: `#663399`,
-        display: `minimal-ui`,
-        icon: `src/images/gatsby-icon.png`, // This path is relative to the root of the site.
+        name: 'gatsby-starter-default',
+        short_name: 'starter',
+        start_url: '/',
+        background_color: '#663399',
+        theme_color: '#663399',
+        display: 'minimal-ui',
+        icon: 'src/images/gatsby-icon.png', // This path is relative to the root of the site.
       },
     },
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,
   ],
-}
+};

--- a/src/templates/tagResults.jsx
+++ b/src/templates/tagResults.jsx
@@ -1,9 +1,9 @@
-import React from "react"
-import { Link, graphql } from "gatsby"
+import React from 'react';
+import { Link, graphql } from 'gatsby';
 
-import Layout from "../components/layout"
+import Layout from '../components/layout';
 import EntryMeta from '../components/Shared/EntryMeta';
-import SEO from "../components/seo";
+import SEO from '../components/seo';
 import FluidImage from '../components/FluidImage';
 
 
@@ -46,45 +46,48 @@ export const tagsPostsQuery = graphql`
           }
         }
   }
-`
+`;
 // { data }
 const TagsPostsList = ({ data }) => {
 //   const { post } = data.wpgraphql
-  console.log(data.wpgraphql.tag)
+  console.log(data.wpgraphql.tag);
   const { tag } = data.wpgraphql;
   const title = tag.name;
-  const posts  = tag.posts.edges;
-  console.log(posts)
+  const posts = tag.posts.edges;
+  console.log(posts);
 
-    return (
-      <Layout>
-        <SEO title="post"/>
-        <h1>#{title}</h1>
-        {posts.map(post => {
+  return (
+    <Layout>
+      <SEO title="post" />
+      <h1>
+#
+        {title}
+      </h1>
+      {posts.map((post) => {
         const postTitle = post.node.title;
         const postExcerpt = post.node.excerpt;
         const tags = post.node.tags.edges;
-        
+
         const { slug, date } = post.node;
 
-        const name = post.node.author.name;
+        const { name } = post.node.author;
         const avatar = post.node.author.avatar.url;
 
-        const featuredImage = post.node.featuredImage;
-        
+        const { featuredImage } = post.node;
+
         return (
-          <div key={post.node.id} className={"post"}>
+          <div key={post.node.id} className="post">
             <FluidImage image={featuredImage} />
             <Link to={slug}>
-              <h1 dangerouslySetInnerHTML={{__html: postTitle}} />
+              <h1 dangerouslySetInnerHTML={{ __html: postTitle }} />
             </Link>
-            <EntryMeta name={name} avatar={avatar} date={date} tags={tags}/>
-            <p dangerouslySetInnerHTML={{__html: postExcerpt}} />
+            <EntryMeta name={name} avatar={avatar} date={date} tags={tags} />
+            <p dangerouslySetInnerHTML={{ __html: postExcerpt }} />
           </div>
-        )
+        );
       })}
-      </Layout>
-    )
-  }
+    </Layout>
+  );
+};
 
 export default TagsPostsList;


### PR DESCRIPTION
qpgraphql plugin has a 100 item limit for API calls, so I was only getting the first 100 tags, even though we really have 139 different tags. As a result, there were 39 tags that would result in a 404 when clicked because those pages never get created.

Made function to fetch all tags (or any other items), not just 100 limit cap. It's DRY enough to use for different item types (blog posts, categories etc.)