### PR TITLE
99 - refactored some of the margins

### DIFF
--- a/src/components/Header/_header.scss
+++ b/src/components/Header/_header.scss
@@ -3,6 +3,7 @@
 .header {
   box-shadow: 0 5px 16px 0 rgba(0,0,0,.11);
   z-index: 1;
+  // margin: 0 0 120px 0;
   .header__logo {
     margin: auto;
     height: 50px;

--- a/src/components/Shared/_heroResults.scss
+++ b/src/components/Shared/_heroResults.scss
@@ -5,6 +5,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  margin: 0 0 120px 0;
   h2 {
     text-align: center;
   }

--- a/src/components/Shared/_heroResults.scss
+++ b/src/components/Shared/_heroResults.scss
@@ -6,7 +6,7 @@
   justify-content: center;
   align-items: center;
   margin: 0 0 120px 0;
-  h2 {
+  h1 {
     text-align: center;
   }
 }

--- a/src/components/_layout.scss
+++ b/src/components/_layout.scss
@@ -79,7 +79,7 @@ p {
 // }
 
 .post {
-  margin: 120px 0px;
+  margin: 0 0 120px 0px;
 }
 
 div.col-sm-7.doc-page {

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -18,7 +18,7 @@ const BlogIndex = ({ data }) => {
   return (
     <Layout>
       <SEO title="Home" />
-      <div className="container">
+      <div className="container" style={{paddingTop: "120px"}}>
       {posts.map((post) => {
         const postTitle = post.node.title;
         const postExcerpt = post.node.excerpt;

--- a/src/templates/PostsIndex.jsx
+++ b/src/templates/PostsIndex.jsx
@@ -16,7 +16,7 @@ const PostsIndex = ({ data, pageContext }) => {
   return (
     <Layout>
       <SEO title="Home" />
-      <div className="container">
+      <div className="container" style={{marginTop: "120px"}}>
         {posts.map((post) => {
           const postTitle = post.node.title;
           const postExcerpt = post.node.excerpt;
@@ -43,7 +43,7 @@ const PostsIndex = ({ data, pageContext }) => {
           return (
             <div key={post.node.id} className="post">
               <FluidImage image={featuredImage} />
-              <a href={slug}>
+              <a href={`/${slug}`}>
                 <h1 dangerouslySetInnerHTML={{ __html: postTitle }} />
               </a>
               <EntryMeta

--- a/src/templates/_post.scss
+++ b/src/templates/_post.scss
@@ -1,7 +1,7 @@
 @import '../components/Shared/variables';
 
 .indexPost {
-  margin: 120px 0px;
+  margin: 120px 0;
 }
 
 .just-comments.myTheme {


### PR DESCRIPTION
Refactored some of the margins, but given that the nav is on page and certain pages have a hero in between the nav and the posts, I don't see any way around having to add margin top on certain pages.

If we add margin bottom to the nav, it'll but down the hero and looks ugly
<img width="218" alt="Screen Shot 2020-03-06 at 11 18 17 AM" src="https://user-images.githubusercontent.com/14118422/76115717-87bc7300-5f9d-11ea-9d9d-203db1819f59.png">
