### PR TITLE
[135] programmatically adding lazy loading attribute to imgs

### DIFF
--- a/src/templates/PostPage.jsx
+++ b/src/templates/PostPage.jsx
@@ -44,10 +44,13 @@ const BlogPostTemplate = ({ data }) => {
               if (domNode.attribs && domNode.attribs['data-src']) {
                 // '?format=pjpg&quality=60&auto=webp' is
                 // appended to img src for Fastly image optimization
+                // 'loading="lazy" is
+                // appended to img src to defer offscreen images in modern browsers
                 return (
                   <img
                     src={`${domNode.attribs['data-src']}?format=pjpg&quality=60&auto=webp`}
                     alt={domNode.attribs.alt}
+                    loading='lazy'
                   />
                 );
               }


### PR DESCRIPTION
Fixes #135 by hooking onto existing programatic img tag injection.

On build, all images in posts will have the `loading="lazy"` attribute added to them. According to CanIUse (https://caniuse.com/#search=loading) this should cover about 67% of visitors, and two of the most popular browser our visitors currently use (with more coming on the way.)