### PR TITLE
[138] removed both aria-labeledby attributes

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -45,7 +45,6 @@ const Footer = () => (
           <section id="footer__social" className="column__horizontal">
             <ul
               className="column__links list-inline"
-              aria-labelledby="social-list"
             >
               <li className="list-inline-item">
                 <a
@@ -146,7 +145,6 @@ const Footer = () => (
           >
             <ul
               className="column__links list-inline"
-              aria-labelledby="company-list"
             >
               <li className="copyright-notice list-inline-item">
                 &copy;


### PR DESCRIPTION
Fixes #138 by removing both aria-labeleby attributes for social-list and company-list.

This should clear the Google Lighthouse error for all pages.