### PR TITLE
added syntax highlighting

### DIFF
--- a/src/components/_layout.scss
+++ b/src/components/_layout.scss
@@ -139,3 +139,28 @@ h4,
 p {
   margin-bottom: 16px;
 }
+
+
+
+pre {
+  background-color: $gray_1;
+  border-radius: 2px;
+  padding: 16px;
+  white-space: pre-wrap; 
+  color: $gray-3; 
+  font-family: monospace !important;
+  line-height: 1.2rem;
+  font-size: 100% !important;
+  code {
+    background: none;
+  }
+}
+code {
+  font-size: 87.5%;
+  color: $gray_1;
+  word-break: break-word;
+  background-color: $gray_3;
+  border-radius: 2px;
+  padding: 4px;
+  font-family: monospace;
+}


### PR DESCRIPTION
prism requires <code> tag. this does not come back from wordpress.
<img width="524" alt="Screen Shot 2020-04-21 at 5 57 23 PM" src="https://user-images.githubusercontent.com/36343528/79929142-b2ea0d00-83f9-11ea-8eee-6c6f82232526.png">


I added background, font and padding: 
<img width="905" alt="Screen Shot 2020-04-21 at 5 57 08 PM" src="https://user-images.githubusercontent.com/36343528/79929135-ae255900-83f9-11ea-9969-e8654790e8ae.png">

