### PR TITLE
added GA and favicon

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -113,7 +113,24 @@ module.exports = {
         background_color: '#663399',
         theme_color: '#663399',
         display: 'minimal-ui',
-        //icon: 'src/images/favicon.png', // This path is relative to the root of the site.
+        icon: 'src/images/favicon.png', // This path is relative to the root of the site.
+      },
+    },
+    {
+      resolve: `gatsby-plugin-google-analytics`,
+      options: {
+        // The property ID; the tracking code won't be generated without it
+        trackingId: "UA-43979731-4",
+        // Defines where to place the tracking script - `true` in the head and `false` in the body
+        head: false,
+        // Setting this parameter is optional
+        anonymize: true,
+        // Setting this parameter is also optional
+        respectDNT: true,
+        // Delays sending pageview hits on route update (in milliseconds)
+        pageTransitionDelay: 0,
+        // Defers execution of google analytics script after page load
+        defer: false,
       },
     },
     // {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11670,6 +11670,15 @@
         }
       }
     },
+    "gatsby-plugin-google-analytics": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.3.0.tgz",
+      "integrity": "sha512-ekXMjLpkoRT6eYC8eOEOhSDLsSBPBsZ6JQydvcmDqy/cCgc+B66icPlqd4G/Lst13Ede2z2cOMuntEsEXf6CvA==",
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "minimatch": "3.0.4"
+      }
+    },
     "gatsby-plugin-just-comments": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-just-comments/-/gatsby-plugin-just-comments-0.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "gatsby-cli": "^2.12.5",
     "gatsby-link": "^2.4.0",
     "gatsby-plugin-algolia": "^0.5.0",
+    "gatsby-plugin-google-analytics": "^2.3.0",
     "gatsby-plugin-just-comments": "^0.2.4",
     "gatsby-plugin-manifest": "^2.4.1",
     "gatsby-plugin-meta-redirect": "^1.1.1",


### PR DESCRIPTION
— GA now shows in prod build
— uncommented out the favicon generator
<img width="1602" alt="Screen Shot 2020-05-01 at 1 21 09 PM" src="https://user-images.githubusercontent.com/4358288/80838871-d6a61380-8bae-11ea-8a39-e35c380156fa.png">
