### PR TITLE
[290] lint - src/components/FluidImage.jsx

### DIFF
--- a/src/components/FluidImage.jsx
+++ b/src/components/FluidImage.jsx
@@ -3,7 +3,7 @@
 import React from 'react';
 // import cooper from '../assets/postman-cooper-fallback.jpg';
 
-const FluidImage = ({ image, ...props }) => {
+const FluidImage = ({ image }) => {
   // Return fallback Image, if no Image is given.
   // const editImage = image.sourceUrl.replace("blog.postman.com", "edit.blog.postman.com")
   if (!image) {
@@ -30,7 +30,7 @@ const FluidImage = ({ image, ...props }) => {
   //   );
   // }
 
-  return <img src={image.sourceUrl} className="img-fluid" alt={image.altText} {...props} />;
+  return <img src={image.sourceUrl} className="img-fluid" alt={image.altText} />;
 };
 
 export default FluidImage;


### PR DESCRIPTION
_branched from `develop`_, this address the props spreading warning; `className` is the only prop in the parent; it's getting reset in the component as "img-fluid"

<img width="543" alt="explicit-className" src="https://user-images.githubusercontent.com/56083362/81601272-7c137100-937f-11ea-89f1-f38ee06ac6ad.png">

fixes #290