### PR TITLE
[294] Header - update spec snapshot

### DIFF
--- a/src/components/Header/__snapshots__/Header.spec.jsx.snap
+++ b/src/components/Header/__snapshots__/Header.spec.jsx.snap
@@ -87,13 +87,38 @@ exports[`Header renders correctly 1`] = `
       <div
         className="input-empty"
       >
-        <ul
-          className="style"
+        <div
+          className="col-sm-12 results-blog"
         >
-          <li>
-            No search results found
-          </li>
-        </ul>
+          <p
+            className="font-weight-bold mb-0"
+          >
+            On the Blog
+          </p>
+          <ul
+            className="style"
+          >
+            <li>
+              No search results found
+            </li>
+          </ul>
+        </div>
+        <div
+          className="col-sm-12 results-lc"
+        >
+          <p
+            className="font-weight-bold mb-0"
+          >
+            On Learning Center
+          </p>
+          <ul
+            className="style"
+          >
+            <li>
+              No search results found
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
     <div


### PR DESCRIPTION
_branched from `develop`_, this updates the Header spec snapshot;

<img width="499" alt="update-HEader-spec-snapshot" src="https://user-images.githubusercontent.com/56083362/81610707-d36d0d80-938e-11ea-9024-e0a9c0a0926a.png">

fixes #294