### PR TITLE
[WEBSITES-526] Global Munchkin (Marketo) code

### DIFF
--- a/scripts/marketo.munchkin.js
+++ b/scripts/marketo.munchkin.js
@@ -1,0 +1,26 @@
+const marketo = () => {
+  if (typeof document === 'object') {
+    /* eslint-disable */
+    var didInit = false;
+    function initMunchkin() {
+      if (didInit === false) {
+        didInit = true;
+        Munchkin.init('067-UMD-991');
+      }
+    }
+    var s = document.createElement('script');
+    s.type = 'text/javascript';
+    s.async = true;
+    s.src = '//munchkin.marketo.net/munchkin.js';
+    s.onreadystatechange = function() {
+      if (this.readyState == 'complete' || this.readyState == 'loaded') {
+        initMunchkin();
+      }
+    };
+    s.onload = initMunchkin;
+    document.getElementsByTagName('head')[0].appendChild(s);
+    /* eslint-enable */
+  }
+};
+
+module.exports = marketo;

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import marketo from '../../scripts/marketo.munchkin';
 // import { useStaticQuery, graphql } from "gatsby"
 
 import Header from './Header/Header';
@@ -29,6 +30,7 @@ const Layout = ({ children }) => (
     <Header />
     <main>{children}</main>
     <Footer />
+    {marketo()}
   </>
 );
 


### PR DESCRIPTION
_Branched from `develop`_, this add, globally, the Munchkin (Marketo) code.
![demo-global-munchkin-code](https://user-images.githubusercontent.com/56083362/81879951-f3443300-9540-11ea-90ee-2606187904a2.gif)
