### PR TITLE
[285] build safeguard (window object)

### DIFF
--- a/src/pages/search.jsx
+++ b/src/pages/search.jsx
@@ -47,13 +47,15 @@ class SearchPage extends Component {
   constructor() {
     super();
 
-    this.state = {
-      searchState: qs.parse(window.location.search.slice(1)),
-    };
+    if (typeof window === 'object') {
+      this.state = {
+        searchState: qs.parse(window.location.search.slice(1)),
+      };
 
-    window.addEventListener('popstate', ({ state: searchState }) => {
-      this.setState({ searchState });
-    });
+      window.addEventListener('popstate', ({ state: searchState }) => {
+        this.setState({ searchState });
+      });
+    }
   }
 
     onSearchStateChange = (searchState) => {
@@ -82,7 +84,7 @@ class SearchPage extends Component {
 
 
     render() {
-      const { searchState } = this.state;
+      const { searchState } = this.state || {};
 
       const parameters = {};
 


### PR DESCRIPTION
Branched from `185-2-1`, this safeguards the build process so it doesn’t try to do things when there isn't a window object, nor state.

![demo-buildable-separate-pg-query-string-url](https://user-images.githubusercontent.com/56083362/82099231-b6507b80-96bb-11ea-9c7c-ef37fc014a1f.gif)
