### PR TITLE
[324] fix PROD deploy (bff)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "bff": "node bff.js",
     "build": "npm run bff && GATSBY_ACTIVE_ENV=development gatsby build",
     "build:dev": "npm run build",
-    "build:prod": "GATSBY_ACTIVE_ENV=production gatsby build",
+    "build:prod": "npm run bff && GATSBY_ACTIVE_ENV=production gatsby build",
     "dev": "npm run bff && gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",


### PR DESCRIPTION
_Branched from `develop`_, this fixes #324; the PROD deploy wasn't including generation of the bff data.