### PR TITLE
[WEBSITES] bff --> api

### DIFF
--- a/bff.js
+++ b/bff.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 
 const host = 'https://postman-web-property-assets.s3.amazonaws.com';
 
-axios.get(`${host}/bff/manifest.json`)
+axios.get(`${host}/api/manifest.json`)
   .then((response) => {
     fs.writeFile('bff.json', JSON.stringify({ ...response.data, host }), (err) => {
       if (err) {


### PR DESCRIPTION
_Branched from `develop`_, this changes “bff” to “api” in the path for the bff,
similar to: https://bitbucket.org/postmanlabs/postman-website-www/pull-requests/5

> a small, but important change, that also gets me to test out the new shiny repos. It makes a small change in the path for the bff; one that’s being made to handle change that’s happening elsewhere, in and around how CMS’s integrate and how the stuff gets deployed. 

https://postman.slack.com/archives/GLLH7EX5Y/p1591307885105500

_*No visuals_