### PR TITLE
[WEBSITES-867] Migrate Bootstrap

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -3,8 +3,5 @@
  *
  * See: https://www.gatsbyjs.org/docs/browser-apis/
  */
-
-// You can delete this file if you're not using it
-
-// }
-
+ 
+import "bootstrap/dist/css/bootstrap.min.css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -4483,6 +4483,11 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
+    "bootstrap": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.1.tgz",
+      "integrity": "sha512-bxUooHBSbvefnIZfjD0LE8nfdPKrtiFy2sgrxQwUZ0UpFzpjVbVMUxaGIoo9XWT4B2LG1HX6UQg0UMOakT0prQ=="
+    },
     "boxen": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "algoliasearch": "^3.35.1",
     "axios": "^0.19.2",
     "babel-jest": "^25.5.1",
+    "bootstrap": "^4.5.1",
     "dotenv": "^8.2.0",
     "eslint-plugin-jest": "^23.16.0",
     "gatsby": "^2.21.33",

--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -92,8 +92,6 @@ function SEO({
       <link rel="canonical" href={canonical} />
       {/* fonts */}
       <link href="https://fonts.googleapis.com/css?family=Roboto:400,500&display=swap" rel="stylesheet" />
-      {/* Bootstrap */}
-      <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossOrigin="anonymous" />
       {/* Algolia IE11 support */}
       <script src="https://polyfill.io/v3/polyfill.min.js?features=default,Array.prototype.find,Array.prototype.includes" />
     </Helmet>


### PR DESCRIPTION
_Branched from `develop`_, this moves code that imports `Bootstrap` from `Helment` (in the `seo` component) to `gatsby-browser`, eliminating a an external CDN call; loads from local dependencies to speed things up (_& get a little more predictable_).

*no visuals
**clean stuff up before running w/ `git checkout develop; git pull; git branch -D feature/WEBSITES-867-Update-Prompt; git checkout feature/WEBSITES-867-Update-Prompt; ./node_modules/.bin/gatsby clean; rm -rf node_modules; npm i`