### PR TITLE
[WEBSITES-537] Newsletter - formProxy API

### DIFF
--- a/bff.js
+++ b/bff.js
@@ -48,6 +48,7 @@ function getPms(names) {
 
 function cachePm() {
   cacheCdn('https://cdn.jsdelivr.net/npm/sanitize-html@1.23.0/dist/sanitize-html.min.js', 'sh');
+  cacheCdn('https://pages.getpostman.com/js/forms2/js/forms2.min.js', 'forms2');
 
   if (!fs.existsSync(cachePmDir)) {
     fs.mkdirSync(cachePmDir, true);

--- a/src/components/Shared/NewsLetterForm.jsx
+++ b/src/components/Shared/NewsLetterForm.jsx
@@ -26,38 +26,54 @@ const handleSubmit = (e) => {
   form.className += 'submitted';
 };
 
+const proxyForm = ({
+  track, id, className, description, form,
+}) => {
+  if (typeof document === 'object' && munchkinId && formid) {
+    let e;
+    let initializedForm;
+
+    const delay = 1000;
+    const loadForm = () => {
+      if (!initializedForm) {
+        initializedForm = true;
+        window.MktoForms2.loadForm('//pages.getpostman.com', munchkinId, formid);
+      }
+    };
+
+    setTimeout(() => {
+      const hasDependencies = window && window.pm && window.pm.cache;
+      if (hasDependencies) {
+        e = document.createElement('script');
+        e.src = `/${window.pm.cache}/forms2.js`;
+        e.onload = () => loadForm();
+        document.head.appendChild(e);
+      }
+    }, delay);
+  }
+
+  return track && id && (
+    <div className={className}>
+      {description}
+      {form}
+      <form id={id} />
+      <style>
+        {`
+        #${id} {
+          display: none !important;
+        }
+      `}
+      </style>
+    </div>
+  );
+};
+
 class Form extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       email: '',
     };
-  }
-
-  componentDidMount() {
-    if (munchkinId && formid) {
-      let initializedForm = false;
-
-      const loadForm = () => {
-        if (initializedForm === false) {
-          initializedForm = true;
-          window.MktoForms2.loadForm('//pages.getpostman.com', munchkinId, formid);
-        }
-      };
-      const s = document.createElement('script');
-
-      s.type = 'text/javascript';
-      s.async = true;
-      s.src = '//pages.getpostman.com/js/forms2/js/forms2.min.js';
-      s.onreadystatechange = () => {
-        if (this.readyState === 'complete' || this.readyState === 'loaded') {
-          loadForm();
-        }
-      };
-      s.onload = loadForm;
-
-      document.getElementsByTagName('head')[0].appendChild(s);
-    }
   }
 
   onEmailChange(event) {
@@ -73,46 +89,41 @@ class Form extends React.Component {
 
     return (
       <div className="row">
-        {
-          munchkinId && formid && (
-            <div className="col-lg-8 offset-lg-2">
+        <div className="col-lg-8 offset-lg-2">
+          {proxyForm({
+            track: munchkinId,
+            id: mktoFormId,
+            className: 'form-container',
+            description: (
               <div className="col-sm-12 col-md-10 offset-md-1 text-center">
                 <h2>Newsletter signup</h2>
                 <p className="mb-4"><em>Like this post? We&#39;ve got plenty more in our monthly newsletter. Have it automatically delivered to your inbox.</em></p>
               </div>
-              <div className="form-container">
-                <form id="contactForm" method="POST" onSubmit={handleSubmit}>
-                  <ul className="inline-form">
-                    <li className="form-field">
-                      <input
-                        id="user_mail"
-                        className="form_input"
-                        type="email"
-                        placeholder="Work Email"
-                        name="user_mail"
-                        maxLength="100"
-                        required
-                        value={email}
-                        onChange={this.onEmailChange.bind(this)}
-                      />
-                    </li>
-                    <li className="button-wrap">
-                      <button className="form-submit-button" type="submit">Submit</button>
-                    </li>
-                  </ul>
-                </form>
-                <form id={mktoFormId} />
-                <style>
-                  {`
-                  #${mktoFormId} {
-                    display: none !important;
-                  }
-                `}
-                </style>
-              </div>
-            </div>
-          )
-        }
+            ),
+            form: (
+              <form id="contactForm" method="POST" onSubmit={handleSubmit}>
+                <ul className="inline-form">
+                  <li className="form-field">
+                    <input
+                      id="user_mail"
+                      className="form_input"
+                      type="email"
+                      placeholder="Work Email"
+                      name="user_mail"
+                      maxLength="100"
+                      required
+                      value={email}
+                      onChange={this.onEmailChange.bind(this)}
+                    />
+                  </li>
+                  <li className="button-wrap">
+                    <button className="form-submit-button" type="submit">Submit</button>
+                  </li>
+                </ul>
+              </form>
+            ),
+          })}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
_Branched from `develop`_, this isolates set up for the Newsletter form by using a proxyForm API; _an incremental step_. Also, it uses bff logic to cache the `MktoForms2` library local to the app, eliminating a live call (over the wire) dependency.

I developed (_& tested_) it locally using Gatsby build & serve; building w/: `MUNCHKIN_ID=SECRET NEWSLETTER_FORM_ID=SECRET GATSBY_ALGOLIA_APP_ID=SECRET GATSBY_ALGOLIA_SEARCH_KEY=SECRET ALGOLIA_ADMIN_KEY=SECRET RSS_URL=https://f3c7231b-164a-47d2-b0ad-0758e71f9ce6.mock.pstmn.io/sub-processors/json npm run build` 

The next PR will import a (_bff_) runtime utility that wraps the isolated logic up, so it doesn't need to be native to the app; _utility to be reused on www_.

*no visuals (_looks the same as before_)