### PR TITLE
[WEBSITES-537] runtime formProxy utility (NewsletterForm)

### DIFF
--- a/bff.js
+++ b/bff.js
@@ -1,9 +1,9 @@
 const axios = require('axios').default;
-const React = require('react');
 const fs = require('fs');
 const path = require('path');
 const sh = require('shelljs');
-const pmUtilities = ['sanatizeContent'];
+
+const pmUtilities = ['sanatizeContent', 'proxyForm'];
 
 const host = 'https://postman-web-property-assets.s3.amazonaws.com';
 
@@ -59,45 +59,57 @@ function cachePm() {
 
 axios.get(`${host}/api/manifest.json`)
   .then((response) => {
-  	bff = { ...response.data, host };
-  	bffUrl = `${bff.host}/${bff.path}`;
-	cacheDirName = `cache-${bff.path.replace(/(api|bff)\//, '').replace('/', '_')}`;
-	cacheDir = path.join('public', cacheDirName);
-	cachePmDir = path.join(cacheDir, 'pm');
-	script = `
-	  var d = 1000, t, z;
-	  load('/${cacheDirName}/sh.js');
-	  loadPms(${JSON.stringify(pmUtilities)});
-	  if (!z) {
-	    clearTimeout(t);
-	    t = setTimeout(function(){
-	      if (window.pm && window.pm.sanatizeContent) {
-	        window.pm.cache = '${cacheDirName}';
-	        clearTimeout(t);
-	      }
-	    }, d);
-	  }
-	  function load(src) {
-	    var e = document.createElement('script');
-	    e.src = src;
-	    document.head.appendChild(e);
-	  }
-	  function loadPm(name) {
-	    load('/${cacheDirName}/pm/' + name + '.js');
-	  }
-	  function loadPms(names) {
-	    var i, max = names.length;
-	    for (i = 0; i < max; i++) {
-	      loadPm(names[i]);
-	    }
-	  }
-	`;	
+    bff = { ...response.data, host };
+    bffUrl = `${bff.host}/${bff.path}`;
+    cacheDirName = `cache-${bff.path.replace(/(api|bff)\//, '').replace('/', '_')}`;
+    cacheDir = path.join('public', cacheDirName);
+    cachePmDir = path.join(cacheDir, 'pm');
+    script = `
+    var d = 1000, t, z;
+    load('/${cacheDirName}/sh.js');
+    loadPms(${JSON.stringify(pmUtilities)});
+    if (!z) {
+      clearTimeout(t);
+      t = setTimeout(function(){
+        if (window.pm && window.pm.sanatizeContent) {
+          window.pm.cache = '${cacheDirName}';
+          clearTimeout(t);
+        }
+      }, d);
+    }
+    window.lazyLoadPmUtility = function(name, cb, optionalDelay) {
+      var delay = optionalDelay || 1000;
+      setTimeout(function(){
+        var hasDependencies = window && window.pm && window.pm.cache;
+        if (hasDependencies) {
+          const e = document.createElement('script');
+          e.src = '/' + window.pm.cache + '/pm/' + name + '.js';
+          e.onload = cb;
+          document.head.appendChild(e);
+        }
+      }, delay);
+    }
+    function load(src) {
+      var e = document.createElement('script');
+      e.src = src;
+      document.head.appendChild(e);
+    }
+    function loadPm(name) {
+      load('/${cacheDirName}/pm/' + name + '.js');
+    }
+    function loadPms(names) {
+      var i, max = names.length;
+      for (i = 0; i < max; i++) {
+        loadPm(names[i]);
+      }
+    }
+  `;
 
     fs.writeFile('bff.json', JSON.stringify({ ...response.data, host, script }), (err) => {
       if (err) {
         throw err;
       } else {
-      	cachePm();
+        cachePm();
       }
     });
   });

--- a/src/components/Shared/NewsLetterForm.jsx
+++ b/src/components/Shared/NewsLetterForm.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import proxyForm from '../../utils/proxyForm';
 
 const munchkinId = process.env.MUNCHKIN_ID || '';
 const formid = process.env.NEWSLETTER_FORM_ID || 0;
@@ -24,48 +25,6 @@ const handleSubmit = (e) => {
   formSubmit.innerHTML = 'Thank you';
 
   form.className += 'submitted';
-};
-
-const proxyForm = ({
-  track, id, className, description, form,
-}) => {
-  if (typeof document === 'object' && munchkinId && formid) {
-    let e;
-    let initializedForm;
-
-    const delay = 1000;
-    const loadForm = () => {
-      if (!initializedForm) {
-        initializedForm = true;
-        window.MktoForms2.loadForm('//pages.getpostman.com', munchkinId, formid);
-      }
-    };
-
-    setTimeout(() => {
-      const hasDependencies = window && window.pm && window.pm.cache;
-      if (hasDependencies) {
-        e = document.createElement('script');
-        e.src = `/${window.pm.cache}/forms2.js`;
-        e.onload = () => loadForm();
-        document.head.appendChild(e);
-      }
-    }, delay);
-  }
-
-  return track && id && (
-    <div className={className}>
-      {description}
-      {form}
-      <form id={id} />
-      <style>
-        {`
-        #${id} {
-          display: none !important;
-        }
-      `}
-      </style>
-    </div>
-  );
 };
 
 class Form extends React.Component {

--- a/src/utils/proxyForm.jsx
+++ b/src/utils/proxyForm.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+const proxyForm = ({
+  track, id, className, description, form,
+}) => {
+  if (typeof document === 'object' && track && id) {
+    window.lazyLoadPmUtility('proxyForm', () => {
+      window.pm.proxyForm({
+        host: '//pages.getpostman.com',
+        track,
+        id,
+      });
+    });
+
+    return (
+      <div className={className}>
+        {description}
+        {form}
+        <form id={id} />
+        <style>
+          {`
+          #${id} {
+            display: none !important;
+          }
+        `}
+        </style>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+export default proxyForm;


### PR DESCRIPTION
_Branched from `develop`_, this consumes the proxyForm runtime (_bff_) utility, removing the native logic; _incremental step from #448_. Additionally, it adds a "lazyLoadPmUtility" method to the bff script; _I'm going to add to www too_.

I developed (_& tested_) it locally using Gatsby build & serve; building w/: `MUNCHKIN_ID=SECRET NEWSLETTER_FORM_ID=SECRET GATSBY_ALGOLIA_APP_ID=SECRET GATSBY_ALGOLIA_SEARCH_KEY=SECRET ALGOLIA_ADMIN_KEY=SECRET RSS_URL=https://f3c7231b-164a-47d2-b0ad-0758e71f9ce6.mock.pstmn.io/sub-processors/json npm run build` 

*no visuals (_looks the same as before_)